### PR TITLE
fix(frontend): add nginx spa fallback

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -6,6 +6,7 @@ COPY . .
 RUN npm run build
 
 FROM nginx:alpine
+COPY nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=build /app/dist /usr/share/nginx/html
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,15 @@
+server {
+  listen 80;
+  server_name _;
+
+  root /usr/share/nginx/html;
+  index index.html;
+
+  location / {
+    try_files $uri $uri/ /index.html;
+  }
+
+  location /assets/ {
+    add_header Cache-Control "public, max-age=31536000, immutable";
+  }
+}


### PR DESCRIPTION
## Summary
- add a custom `frontend/nginx.conf` that falls back to `index.html` for any unknown route
- update the frontend Dockerfile to copy that config into `/etc/nginx/conf.d/default.conf`
- rebuild instructions added so container picks up the new config

## Testing
- `docker compose -f infrastructure/docker-compose.yml down`
- `docker compose -f infrastructure/docker-compose.yml up -d --build`
- refresh `http://localhost:5173/`, `/login`, `/profile` → all load without Nginx 404
